### PR TITLE
NEW: Root trees using an outgroup sample

### DIFF
--- a/genome_sampler/root_outgroup.py
+++ b/genome_sampler/root_outgroup.py
@@ -1,0 +1,10 @@
+from skbio import TreeNode
+
+
+# Should node be a string?
+def root_outgroup(tree: TreeNode, node: str) -> TreeNode:
+    # Since the outgroup node passed will always be a tip it will always have
+    # exactly one neighbor.
+    # TODO: Maybe we make an explicit check and error on more than one
+    # neighbor?
+    return tree.root_at(tree.find(node).neighbors[0])

--- a/genome_sampler/root_outgroup.py
+++ b/genome_sampler/root_outgroup.py
@@ -1,10 +1,29 @@
 from skbio import TreeNode
 
 
-# Should node be a string?
-def root_outgroup(tree: TreeNode, node: str) -> TreeNode:
-    # Since the outgroup node passed will always be a tip it will always have
-    # exactly one neighbor.
-    # TODO: Maybe we make an explicit check and error on more than one
-    # neighbor?
-    return tree.root_at(tree.find(node).neighbors[0])
+def root_outgroup(tree: TreeNode, node: str,
+                  remove_outgroup: bool = True) -> TreeNode:
+    fake_node = _insert_fake_parent(tree.find(node))
+    rooted = tree.root_at(fake_node)
+
+    new_subtree = rooted.find(fake_node.name)
+    new_subtree.name = None
+
+    return new_subtree if remove_outgroup else rooted
+
+
+def _insert_fake_parent(node):
+    real_parent = node.parent
+    # We don't actually care what this node is called because it will become an
+    # unnamed inner node. This name was chosen to avoid collisions
+    fake_node = TreeNode(name='~~!ROOT_BRANCH!~~')
+    for idx, child in enumerate(real_parent.children):
+        if child is node:
+            break
+
+    del real_parent.children[idx]
+    real_parent.children.append(fake_node)
+    fake_node.children.append(node)
+    node.parent = fake_node
+    fake_node.parent = real_parent
+    return fake_node

--- a/genome_sampler/tests/test_root_outgroup.py
+++ b/genome_sampler/tests/test_root_outgroup.py
@@ -1,0 +1,63 @@
+from skbio import TreeNode
+
+from qiime2.plugin.testing import TestPluginBase
+
+from genome_sampler.root_outgroup import root_outgroup
+
+
+class TestRootOutgroup(TestPluginBase):
+    package = 'genome_sampler.tests'
+
+    def setUp(self):
+        super().setUp()
+
+        self.bifurcated_tree = TreeNode.read(['(((a,b)c,(d,e)f)g,i);'])
+        self.trifurcated_tree = TreeNode.read(['(((a,b)c,(d,e)f)g,h,(j,k)i);'])
+
+    def test_bifurcation_shallow_remove(self):
+        obs = str(root_outgroup(self.bifurcated_tree, 'i'))
+        exp = '(((a,b)c,(d,e)f)g);\n'
+
+        self.assertEqual(obs, exp)
+
+    def test_bifurcation_shallow_keep(self):
+        obs = str(root_outgroup(self.bifurcated_tree, 'i', False))
+        exp = '(i,(((a,b)c,(d,e)f)g))root;\n'
+
+        self.assertEqual(obs, exp)
+
+    def test_bifurcation_deep_remove(self):
+        obs = str(root_outgroup(self.bifurcated_tree, 'a'))
+        exp = '(b,((d,e)f,(i)g)c);\n'
+
+        self.assertEqual(obs, exp)
+
+    def test_bifurcation_deep_keep(self):
+        obs = str(root_outgroup(self.bifurcated_tree, 'a', False))
+        exp = '(a,(b,((d,e)f,(i)g)c))root;\n'
+
+        self.assertEqual(obs, exp)
+
+    def test_trifurcation_shallow_remove(self):
+        obs = str(root_outgroup(self.trifurcated_tree, 'h'))
+        exp = '(((a,b)c,(d,e)f)g,(j,k)i);\n'
+
+        self.assertEqual(obs, exp)
+
+    def test_trifurcation_shallow_keep(self):
+        obs = str(root_outgroup(self.trifurcated_tree, 'h', False))
+        exp = '(h,(((a,b)c,(d,e)f)g,(j,k)i))root;\n'
+
+        self.assertEqual(obs, exp)
+
+    def test_trifurcation_deep_remove(self):
+        obs = str(root_outgroup(self.trifurcated_tree, 'a'))
+        exp = '(b,((d,e)f,(h,(j,k)i)g)c);\n'
+
+        self.assertEqual(obs, exp)
+
+    def test_trifurcation_deep_keep(self):
+        obs = str(root_outgroup(self.trifurcated_tree, 'a', False))
+        exp = '(a,(b,((d,e)f,(h,(j,k)i)g)c))root;\n'
+
+        self.assertEqual(obs, exp)


### PR DESCRIPTION
I think this is something along the lines of what we want here? Do we maybe want to use `find_by_id` instead of `find`? Additionally, some of the behavior of the `root_at` method seems a bit funky to me, but it may just be me misinterpreting the results.

___
![image](https://user-images.githubusercontent.com/10642616/88861068-08307a00-d1b2-11ea-96e6-1087cc68415c.png)
___

The first tree in that image is unrooted. The second should be rooted at `a`. The third at `f`. The tree was already "rooted" at `a`, and telling it to actually root at `a` looks like it just replaced the `a` with the word `root`. So now we have no `a`. And I confirmed by trying to find `a` in that tree that `a` no longer exists. 

`a` also inexplicably doesn't exist in the `f` rooted tree which also isn't actually rooted at `f`. Any time I tried to root at anything other than `a` I got something similar to the `f` rooted tree (i.e. something not actually rooted where I thought I told it to and without an `a` node)