### PR TITLE
LOCK: prevent accidental package publication

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,8 @@ jobs:
         package-name: genome-sampler
         additional-tests: pytest --pyargs genome_sampler
         build-target: release
-        library-token: ${{ secrets.LIBRARY_TOKEN }}
+        # removed the token to prevent automatically publishing patch builds
+        library-token:
 
   integrate:
     needs: build-and-test


### PR DESCRIPTION
This will prevent the CI from publishing any new commits on this branch automatically as patch-build packages.