### PR TITLE
address memory issue with large GISAID files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
     # TODO: any way to cache and extract the miniconda
     # installation included in action-library-packaging?
     - name: setup miniconda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         python-version: 3.6

--- a/genome_sampler/plugin_setup.py
+++ b/genome_sampler/plugin_setup.py
@@ -1,4 +1,6 @@
 import sys
+import os
+import tempfile
 import skbio
 import pandas as pd
 
@@ -151,7 +153,13 @@ def _read_gisaid_dna_fasta(path):
             if lines is not None:
                 yield from lines
 
-    result = skbio.io.read(_cleanup_gen(), verify=False,
+    # perform an initial clean-up pass through the file. if _cleanup_gen() 
+    # is passed directly to skbio.io.read, the file ends up being read into
+    # memory, which is a problem for large files
+    fh = tempfile.TemporaryFile(mode='w+')
+    fh.writelines(_cleanup_gen())
+    fh.seek(0)
+    result = skbio.io.read(fh, verify=False,
                            format='fasta', constructor=skbio.DNA)
     return result
 

--- a/genome_sampler/plugin_setup.py
+++ b/genome_sampler/plugin_setup.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import tempfile
 import skbio
 import pandas as pd
@@ -153,7 +152,7 @@ def _read_gisaid_dna_fasta(path):
             if lines is not None:
                 yield from lines
 
-    # perform an initial clean-up pass through the file. if _cleanup_gen() 
+    # perform an initial clean-up pass through the file. if _cleanup_gen()
     # is passed directly to skbio.io.read, the file ends up being read into
     # memory, which is a problem for large files
     fh = tempfile.TemporaryFile(mode='w+')


### PR DESCRIPTION
This does address the memory issue but is probably not the most elegant approach. Note that explicitly closing `fh` or using a context manager results in the file being closed too early, so I'm relying on `tempfile` to ensure that `fh` is closed. Open to suggestions on how to better address this.