### PR TITLE
MAINT: moving Selection type, IDSelection formats to q2-types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         package-name: genome-sampler
         additional-tests: pytest --pyargs genome_sampler
-        build-target: staging
+        build-target: dev
         library-token: ${{ secrets.LIBRARY_TOKEN }}
 
   integrate:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -30,7 +30,6 @@ test:
   imports:
     - genome_sampler
     - qiime2.plugins.genome_sampler
-    - qiime2.plugins.q2_types
 
 about:
   home: https://github.com/caporaso-lab/genome-sampler

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
   imports:
     - genome_sampler
     - qiime2.plugins.genome_sampler
+    - qiime2.plugins.q2_types
 
 about:
   home: https://github.com/caporaso-lab/genome-sampler

--- a/genome_sampler/combine.py
+++ b/genome_sampler/combine.py
@@ -2,7 +2,7 @@ import operator
 
 import qiime2
 
-from genome_sampler.common import IDSelection
+from q2_types._format import IDSelection
 
 
 def _combine_df_error_if_not_equal(a, b):

--- a/genome_sampler/common.py
+++ b/genome_sampler/common.py
@@ -1,24 +1,10 @@
 import subprocess
 
-import pandas as pd
 import skbio
 import vcf
 
-import qiime2
 import qiime2.plugin.model as model
-from qiime2.plugin import SemanticType
-from q2_types.feature_data import FeatureData
-from qiime2.plugin import ValidationError
-
-
-class UNIXListFormat(model.TextFileFormat):
-    def _validate_(self, level):
-        # any file with lines will be valid
-        return True
-
-    def to_list(self):
-        with self.open() as fh:
-            return [s.strip() for s in fh]
+from qiime2.plugin import (SemanticType, ValidationError)
 
 
 class VCFMaskFormat(model.TextFileFormat):
@@ -34,35 +20,6 @@ class VCFMaskFormat(model.TextFileFormat):
 
 VCFMaskDirFmt = model.SingleFileDirectoryFormat(
     'VCFMaskDirFmt', 'mask.tsv', VCFMaskFormat)
-
-
-class IDMetadataFormat(model.TextFileFormat):
-    def _validate_(self, level):
-        try:
-            self.to_metadata()
-        except qiime2.metadata.MetadataFileError as md_exc:
-            raise model.ValidationError(md_exc) from md_exc
-
-    def to_metadata(self):
-        return qiime2.Metadata.load(str(self))
-
-
-class IDSelectionDirFmt(model.DirectoryFormat):
-    included = model.File('included.txt', format=UNIXListFormat)
-    excluded = model.File('excluded.txt', format=UNIXListFormat)
-    metadata = model.File('metadata.tsv', format=IDMetadataFormat)
-    label = model.File('label.txt', format=UNIXListFormat)
-
-
-class IDSelection:
-    def __init__(self, inclusion: pd.Series, metadata: qiime2.Metadata,
-                 label: str):
-        self.inclusion = inclusion
-        self.metadata = metadata
-        self.label = label
-
-
-Selection = SemanticType('Selection', variant_of=FeatureData.field['type'])
 
 AlignmentMask = SemanticType('AlignmentMask')
 

--- a/genome_sampler/mask.py
+++ b/genome_sampler/mask.py
@@ -33,7 +33,7 @@ def _rle(inarray):
         i = np.append(np.where(y), n - 1)    # must include last element posi
         z = np.diff(np.append(-1, i))        # run lengths
         p = np.cumsum(np.append(0, z))[:-1]  # positions
-        return(z, p, ia[i])
+        return (z, p, ia[i])
 
 
 def _find_terminal_gaps(aligned_seq):

--- a/genome_sampler/sample_diversity.py
+++ b/genome_sampler/sample_diversity.py
@@ -4,8 +4,9 @@ import pandas as pd
 
 import qiime2
 from q2_types.feature_data import DNAFASTAFormat
+from q2_types._format import IDSelection
 
-from genome_sampler.common import IDSelection, run_command, ids_from_fasta
+from genome_sampler.common import run_command, ids_from_fasta
 
 
 # According to the vsearch 2.14.2 documentation, percent_id is defined as:

--- a/genome_sampler/sample_longitudinal.py
+++ b/genome_sampler/sample_longitudinal.py
@@ -3,8 +3,9 @@ import numpy as np
 
 import qiime2
 from q2_types.feature_data import DNAFASTAFormat
+from q2_types._format import IDSelection
 
-from genome_sampler.common import IDSelection, ids_from_fasta
+from genome_sampler.common import ids_from_fasta
 
 
 def _sample_group(samples_per_interval, seed):

--- a/genome_sampler/sample_neighbors.py
+++ b/genome_sampler/sample_neighbors.py
@@ -6,8 +6,9 @@ import numpy as np
 import qiime2
 from qiime2.metadata import CategoricalMetadataColumn
 from q2_types.feature_data import DNAFASTAFormat
+from q2_types._format import IDSelection
 
-from genome_sampler.common import IDSelection, run_command, ids_from_fasta
+from genome_sampler.common import run_command, ids_from_fasta
 
 
 def _clusters_from_vsearch_out(vsearch_out, locale):

--- a/genome_sampler/sample_random.py
+++ b/genome_sampler/sample_random.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import qiime2
 
-from genome_sampler.common import IDSelection
+from q2_types._format import IDSelection
 
 
 def sample_random(ids: qiime2.Metadata, n: int, seed: int = None) \

--- a/genome_sampler/summarize.py
+++ b/genome_sampler/summarize.py
@@ -5,7 +5,7 @@ import pandas as pd
 import q2templates
 
 
-from genome_sampler.common import IDSelection
+from q2_types._format import IDSelection
 
 SUMMARY_TEMPLATE = pkg_resources.resource_filename(
     'genome_sampler', 'assets/summarize/index.html')

--- a/genome_sampler/tests/test_combine.py
+++ b/genome_sampler/tests/test_combine.py
@@ -4,9 +4,9 @@ import numpy as np
 
 import qiime2
 from qiime2.plugin.testing import TestPluginBase
+from q2_types._format import IDSelection
 
 from genome_sampler.combine import combine_selections
-from genome_sampler.common import IDSelection
 
 
 class TestCombineSelections(TestPluginBase):


### PR DESCRIPTION
This PR is paired with another in [q2-types](https://github.com/qiime2/q2-types/pull/282), which moves over the following semantic type, formats, and associated transformers:

File/directory formats:
`UNIXListFormat`
`IDSelection`
`IDSelectionDirectoryFormat`
`IDMetadataFormat`

Semantic Type:
`FeatureData[Selection]`